### PR TITLE
Change link to Jim Liddell's blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ implicit val personMarshaller = Marshaller.oneOf[Person, NodeSeq](opaquePersonMa
 
 # Vendor specific media types
 Versioning an API can be tricky. The key is choosing a strategy on how to do versioning. I have found and tried the following stragegies as
-blogged by [Jim Lidell's blog](http://liddellj.com/using-media-type-parameters-to-version-an-http-api/), which is great by the way!
+blogged by [Jim Liddell's blog](https://web.archive.org/web/20151001093016/http://liddellj.com/using-media-type-parameters-to-version-an-http-api/), which is great by the way!
 
 1. 'The URL is king' in which the URL is encoded in the URL eg. `http://localhost:8080/api/v1/person`. The downside of this strategy is that
 the location of a resource may not change, and when we request another representation, the url does change eg. to `http://localhost:8080/api/v2/person`.


### PR DESCRIPTION
My blog is down just now while I transition to a new platform. In the meantime you could link to Way Back Machine if you wish. Additionally, there was a wee typo in my surname. I'll try to get my proper blog back up and running again. I plan to maintain existing URIs wherever possible.
