### PR TITLE
Vanity URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ implicit val personMarshaller = Marshaller.oneOf[Person, NodeSeq](opaquePersonMa
 
 # Vendor specific media types
 Versioning an API can be tricky. The key is choosing a strategy on how to do versioning. I have found and tried the following stragegies as
-blogged by [Jim Liddell's blog](http://liddellj.com/2014/01/08/using-media-type-parameters-to-version-an-http-api.html), which is great by the way!
+blogged by [Jim Liddell's blog](http://liddellj.com/2014/01/08/using-media-type-parameters-to-version-an-http-api), which is great by the way!
 
 1. 'The URL is king' in which the URL is encoded in the URL eg. `http://localhost:8080/api/v1/person`. The downside of this strategy is that
 the location of a resource may not change, and when we request another representation, the url does change eg. to `http://localhost:8080/api/v2/person`.


### PR DESCRIPTION
I'm sorry.

It was bothering me that Jekyll's default URLs include a `.html` extension, so I figured out how to change that by re-configuring the permalink format. Your existing link still works, but _this_ is now the canonical link. I won't change it again, promise :grin:
